### PR TITLE
feat: Complete Trial of Finality module

### DIFF
--- a/conf/mod_trial_of_finality.conf
+++ b/conf/mod_trial_of_finality.conf
@@ -18,6 +18,8 @@ Arena.TeleportX = -13224.9
 Arena.TeleportY = 222.2
 Arena.TeleportZ = 30.5
 Arena.TeleportO = 2.3
+# Radius of the arena boundary, in yards, from the teleport-in point.
+Arena.Radius = 100.0
 # NPC Scaling
 NpcScaling.Mode = "match_highest_level" # Options: "match_highest_level", "custom_scaling_rules" (future)
 


### PR DESCRIPTION
This commit completes the implementation of the `mod-trial-of-finality` module, filling in all placeholder functions and delivering the full feature set as described in the project documentation.

Key features implemented include:
- A full trial lifecycle from initiation to completion.
- A group confirmation system with timeouts for players to opt-in to the trial.
- A 5-wave combat encounter system with scaling NPC count and difficulty.
- Perma-death mechanics for failed trials, with resurrection providing a chance to be saved mid-wave.
- Arena boundary enforcement to ensure players remain within the challenge area.
- A scripted announcer NPC to provide flavor and announce waves.
- A GM command (`.trial test start`) to allow for solo testing.
- Comprehensive database logging for all significant trial events.
- All features are configurable via the `mod_trial_of_finality.conf` file.

The implementation addresses previous placeholder code and fulfills the project's goals as outlined in the README. It also includes database query optimizations based on code review feedback.