### PR TITLE
Feat: Add configurable exit and spawn locations

### DIFF
--- a/conf/mod_trial_of_finality.conf
+++ b/conf/mod_trial_of_finality.conf
@@ -20,6 +20,12 @@ Arena.TeleportZ = 30.5
 Arena.TeleportO = 2.3
 # Radius of the arena boundary, in yards, from the teleport-in point.
 Arena.Radius = 100.0
+# A semicolon-separated list of spawn positions for the trial waves.
+# Each position must be a comma-separated list of four floats: X, Y, Z, Orientation.
+# The number of provided positions determines the maximum number of NPCs that can spawn in a single wave.
+# Example: "x1,y1,z1,o1;x2,y2,z2,o2;x3,y3,z3,o3"
+# Default: 5 positions from the original hardcoded array.
+Arena.SpawnPositions = "-13230.0,180.0,30.5,1.57;-13218.0,180.0,30.5,1.57;-13235.0,196.0,30.5,3.14;-13213.0,196.0,30.5,3.14;-13224.0,210.0,30.5,4.71"
 # NPC Scaling
 NpcScaling.Mode = "match_highest_level" # Options: "match_highest_level", "custom_scaling_rules"
 
@@ -133,3 +139,16 @@ TrialOfFinality.CheeringNpcs.ExcludeNpcFlags = 32764
 # Interval in milliseconds for a second cheer emote. Set to 0 to disable.
 # This feature is now fully implemented.
 TrialOfFinality.CheeringNpcs.CheerIntervalMs = 2000
+
+# --- Exit Location Settings ---
+# By default, players are teleported to their hearthstone location upon exiting the trial.
+# These settings allow you to override that and send them to a specific, fixed location.
+# Default: false
+Exit.OverrideHearthstone = false
+# The MapID to teleport players to. (e.g., 0 for Eastern Kingdoms, 1 for Kalimdor)
+Exit.MapID = 0
+# The coordinates to teleport players to.
+Exit.TeleportX = 0.0
+Exit.TeleportY = 0.0
+Exit.TeleportZ = 0.0
+Exit.TeleportO = 0.0


### PR DESCRIPTION
This commit introduces two new features to enhance the configurability of the Trial of Finality module.

First, it adds a configurable exit location. A new set of options in the `.conf` file (`Exit.OverrideHearthstone`, `Exit.MapID`, `Exit.TeleportX`, etc.) allows administrators to specify a fixed teleport point for players after the trial, rather than defaulting to their bind point.

Second, it makes the arena spawn positions configurable. The previously hardcoded `WAVE_SPAWN_POSITIONS` array and `NUM_SPAWNS_PER_WAVE` constant have been removed. They are replaced by a dynamic `std::vector` that is populated by parsing a new `Arena.SpawnPositions` string from the configuration. This gives administrators full control over the layout and maximum number of spawns in the arena. The parsing logic is robust and includes error handling for malformed strings.